### PR TITLE
Add CMake and MSVC support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,18 @@ set(_SOURCE_FILES
     )
 
 find_package(sdl2 REQUIRED CONFIG)
+set(_INCLUDE_DIRS ${SDL2_INCLUDE_DIRS})
+set(_LIBS ${SDL2_LIBRARIES})
+
+if (_UNAME STREQUAL "LINUX")
+  find_package(X11 REQUIRED)
+  list(APPEND _INCLUDE_DIRS ${X11_INCLUDE_DIR})
+  list(APPEND _LIBS ${X11_LIBRARIES})
+endif()
 
 add_executable(lwp
     ${_SOURCE_FILES}
     )
 target_compile_definitions(lwp PUBLIC __${_UNAME})
-target_include_directories(lwp PUBLIC ${SDL2_INCLUDE_DIRS})
-target_link_libraries(lwp PRIVATE SDL2::SDL2)
+target_include_directories(lwp PUBLIC ${_INCLUDE_DIRS})
+target_link_libraries(lwp PRIVATE ${_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(lwp
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+# Detect the platform
 if (APPLE)
   set(_UNAME "DARWIN")
 elseif (WIN32)
@@ -21,19 +22,38 @@ set(_SOURCE_FILES
     window.c
     )
 
+# SDL2 dependency
 find_package(sdl2 REQUIRED CONFIG)
 set(_INCLUDE_DIRS ${SDL2_INCLUDE_DIRS})
 set(_LIBS ${SDL2_LIBRARIES})
 
 if (_UNAME STREQUAL "LINUX")
+  # X11 dependency
   find_package(X11 REQUIRED)
   list(APPEND _INCLUDE_DIRS ${X11_INCLUDE_DIR})
   list(APPEND _LIBS ${X11_LIBRARIES})
 endif()
 
+# Config file
+set(_DEFAULT_CONFIG_FILE default.cfg)
+if (_UNAME STREQUAL "DARWIN")
+  set(_DEFAULT_CONFIG_FILE defaultMac.cfg)
+endif()
+
+# Main executable
 add_executable(lwp
     ${_SOURCE_FILES}
     )
 target_compile_definitions(lwp PUBLIC __${_UNAME})
 target_include_directories(lwp PUBLIC ${_INCLUDE_DIRS})
 target_link_libraries(lwp PRIVATE ${_LIBS})
+
+# Installation rules
+install(TARGETS lwp)
+install(DIRECTORY wallpapers
+    DESTINATION share/lwp)
+install(FILES LICENSE
+    DESTINATION share/lwp)
+install(FILES ${_DEFAULT_CONFIG_FILE}
+    TYPE SYSCONF
+    RENAME lwp.cfg)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(lwp
+    LANGUAGES C)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+if (APPLE)
+  set(_UNAME "DARWIN")
+elseif (WIN32)
+  set(_UNAME "WIN32")
+else()
+  set(_UNAME "LINUX")
+endif()
+
+set(_SOURCE_FILES
+    debug.c
+    main.c
+    parser.c
+    wallpaper.c
+    window.c
+    )
+
+find_package(sdl2 REQUIRED CONFIG)
+
+add_executable(lwp
+    ${_SOURCE_FILES}
+    )
+target_compile_definitions(lwp PUBLIC __${_UNAME})
+target_include_directories(lwp PUBLIC ${SDL2_INCLUDE_DIRS})
+target_link_libraries(lwp PRIVATE SDL2::SDL2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
 
 project(lwp
     LANGUAGES C)
@@ -27,12 +27,19 @@ find_package(sdl2 REQUIRED CONFIG)
 set(_INCLUDE_DIRS ${SDL2_INCLUDE_DIRS})
 set(_LIBS ${SDL2_LIBRARIES})
 
+if (_UNAME STREQUAL "DARWIN")
+  # MacOSX framework dependencies
+  list(APPEND _LIBS "-framework CoreGraphics" "-framework Foundation")
+endif()
+
 if (_UNAME STREQUAL "LINUX")
   # X11 dependency
   find_package(X11 REQUIRED)
   list(APPEND _INCLUDE_DIRS ${X11_INCLUDE_DIR})
   list(APPEND _LIBS ${X11_LIBRARIES})
 endif()
+
+option(LWP_INSTALL_LAUNCHD "Launch lwp on login (MacOSX only)" OFF)
 
 # Config file
 set(_DEFAULT_CONFIG_FILE default.cfg)
@@ -57,3 +64,37 @@ install(FILES LICENSE
 install(FILES ${_DEFAULT_CONFIG_FILE}
     TYPE SYSCONF
     RENAME lwp.cfg)
+
+if (_UNAME STREQUAL "DARWIN")
+  # MacOSX specific installation rules
+  execute_process(COMMAND whoami
+      OUTPUT_VARIABLE _USERNAME)
+
+  # The plist file needs absolute path to the binary. In order to
+  # do so we use `configure_file` to replace place holders in the
+  # template with the needed variable. However, users might change
+  # the install prefix during the installation time, and to account
+  # for that we provide a cmake code snippet instead of populating
+  # the install prefix prematurely during configuration time.
+  install(CODE "
+    set(user ${_USERNAME})
+    set(binpath \${CMAKE_INSTALL_PREFIX}/bin/lwp)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/lwp.template.plist
+        \${CMAKE_INSTALL_PREFIX}/lwp.plist
+        @ONLY)
+
+    # Install to launchd in order to run lwp on login
+    if (LWP_INSTALL_LAUNCHD)
+      message(STATUS \"Installing to launchd...\")
+      execute_process(
+        COMMAND mkdir -p ~/Library/LaunchAgents
+        )
+      execute_process(
+        COMMAND cp \${CMAKE_INSTALL_PREFIX}/lwp.plist ~/Library/LaunchAgents/
+        )
+      execute_process(
+        COMMAND launchctl load ~/Library/LaunchAgents/lwp.plist
+        )
+    endif()
+    ")
+endif()

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,8 @@ uninstall:
 # Build the launchd plist file.
 lwp.plist: lwp.template.plist
 	cp lwp.template.plist lwp.plist
-	sed -i "" "s/{{user}}/$$(whoami)/g" lwp.plist
-	sed -i "" "s^{{binpath}}^$(PREFIX)/bin/lwp^g" lwp.plist
+	sed -i "" "s/@user@/$$(whoami)/g" lwp.plist
+	sed -i "" "s^@binpath@^$(PREFIX)/bin/lwp^g" lwp.plist
 
 # Launch lwp on login (macOS only).
 install-launchd: lwp.plist

--- a/README.md
+++ b/README.md
@@ -91,6 +91,26 @@ https://user-images.githubusercontent.com/38699473/220888934-09788a6b-873c-469b-
   
 </details>
 
+## Build from source using CMake
+[CMake](https://cmake.org) is a cross-platform build system generator. Using CMake to build LWP can't be simpler: please install SDL2 first (see platform-specific instructions in the previous section) and then run the following commands:
+```shell
+mkdir -p build
+cd build
+cmake -Dsdl2_DIR=/path/to/SDL2/lib/cmake/SDL2 ../
+```
+The `-Dsdl2_DIR=/path/to/SDL2/lib/cmake/SDL2` flag can be omitted if SDL2 is installed in a commonly known location like `/usr/local`. On Windows however, it's almost certain that you need to pass this flag.
+
+The previous command will generate the real build system scripts. By default, it's Visual Studio project (MSVC) on Windows (if it's installed); on Linux, MinGW, and Mac OSX it's GNU Make.
+Now you can proceed to launch the build command:
+```shell
+cmake --build .
+```
+The executable should be in `build/bin/lwp` (or `build\bin\<build configuration>\lwp` for MSVC).
+
+Note that currently there are two limitations:
+  1. Even if you're generating to MSVC (on Windows), it still depends on MinGW version of SDL2, since it has a different include folder hierarchy than the SDL2 for MSVC.
+  2. On Mac OSX, to install LWP to launchd (i.e. start LWP upon login), instead of `make install-launchd` you have to set the `LWP_INSTALL_LAUNCHD` cmake variable to ON, either during configuration time or installation time like invoking `cmake_install.cmake`.
+
 ## Configuration
 
 #### Create a configuration file

--- a/lwp.template.plist
+++ b/lwp.template.plist
@@ -12,11 +12,11 @@
         <true/>
 
         <key>UserName</key>
-        <string>{{user}}</string>
+        <string>@user@</string>
 
         <key>ProgramArguments</key>
         <array>
-            <string>{{binpath}}</string>
+            <string>@binpath@</string>
         </array>
     </dict>
 </plist>

--- a/main.c
+++ b/main.c
@@ -46,6 +46,9 @@ static void initCmd()
 }
 #endif
 
+// Avoid duplicated definitions of 'main' from SDL2
+#undef main
+
 int main(int argc, char *argv[])
 {
 #ifdef __WIN32

--- a/main.h
+++ b/main.h
@@ -7,6 +7,10 @@
 #include <SDL2/SDL_syswm.h>
 #include <stdio.h>
 #include <windows.h>
+// MSVC doesn't have PATH_MAX
+#ifndef PATH_MAX
+#define PATH_MAX MAX_PATH
+#endif
 #elif __DARWIN
 #include <objc/runtime.h>
 #include <objc/message.h>


### PR DESCRIPTION
This PR adds CMake support as an alternative building method for all supported platforms / toolchains. As a bonus, we can now build on Windows with MSVC 🎉  (I'd tested with VS2019).

Here are the limitations:
  1. On Windows, the path to SDL2 cmake config file has to be manually assigned through command line (i.e. `-Dsdl2_DIR=...`)
  2. Even if you're using MSVC (on Windows), it still depends on Mingw version of SDL2, since it has a different include folder hierarchy than the SDL2 for MSVC.
  3. On Mac OSX, due to the fact that user can change the install prefix (i.e. `CMAKE_INSTALL_PREFIX`) basically anytime, it's hard to materialize `lwp.plist` until installation time, and thus makes it difficult to model `install-launchd` as a build target like what Makefile does. As a workaround, if the user wants to install to launchd, they have to set `LWP_INSTALL_LAUNCHD` variable to ON (either during configuration time or installation time via, says `cmake_install.cmake`).
