### PR TITLE
Add ability to set custom FPS in configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ https://user-images.githubusercontent.com/38699473/220888934-09788a6b-873c-469b-
 | int    | monitor[n]_wallpaper_y | Position of the wallpaper relative to the monitor |
 | int    | monitor[n]_wallpaper_w | Wallpaper resolution |
 | int    | monitor[n]_wallpaper_h | Wallpaper resolution |
+| int    | target_fps     | How many times per second should the wallpaper render (imprecise, hence "target") |
 
 ## Creating Wallpapers
 

--- a/default.cfg
+++ b/default.cfg
@@ -33,3 +33,7 @@ monitor1_wallpaper_x=0
 monitor1_wallpaper_y=0
 monitor1_wallpaper_w=1920
 monitor1_wallpaper_h=1080
+
+# How many times per second should the wallpaper render
+# (imprecise, but accurate enough)
+target_fps=60

--- a/defaultMac.cfg
+++ b/defaultMac.cfg
@@ -31,3 +31,6 @@ monitor1_wallpaper_y=0
 monitor1_wallpaper_w=1920
 monitor1_wallpaper_h=1080
 
+# How many times per second should the wallpaper render
+# (imprecise, but accurate enough)
+target_fps=60

--- a/defaultWin.cfg
+++ b/defaultWin.cfg
@@ -30,3 +30,7 @@ monitor1_wallpaper_x=0
 monitor1_wallpaper_y=0
 monitor1_wallpaper_w=1920
 monitor1_wallpaper_h=1080
+
+# How many times per second should the wallpaper render
+# (imprecise, but accurate enough)
+target_fps=60

--- a/main.c
+++ b/main.c
@@ -44,12 +44,12 @@ static void initCmd()
   DWORD  dwMode = 0;
   GetConsoleMode(hOut, &dwMode);
   SetConsoleMode(hOut, dwMode | 0x0004);
-	
+
 	// Remove closing button (because closing it closes the entire app)
 	HWND hwnd = GetConsoleWindow();
 	HMENU hMenu = GetSystemMenu(hwnd, FALSE);
 	DeleteMenu(hMenu, SC_CLOSE, MF_BYCOMMAND);
-	
+
 	// Set console title
 	SetConsoleTitle("Layered WallPaper");
 }
@@ -58,7 +58,7 @@ static void initCmd()
 int main(int argc, char *argv[])
 {
 	lwpLog(LOG_INFO, "Starting Layered WallPaper");
-	
+
 #ifdef __WIN32
   if (argc == 2 && strcmp(argv[1], "/console") == 0) initCmd();
 	initTrayIcon();
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
   Config cfg;
 
 	int canRender = 1;
-	
+
   if (!parseConfig(&app, &cfg) || !init(&app, &cfg) || !loadMonitors(&app, &cfg)) canRender = 0;
 
   SDL_Event event;
@@ -188,12 +188,12 @@ int main(int argc, char *argv[])
 			}
 			SDL_RenderPresent(app.renderer);
 		}
-		SDL_Delay(1000 / 60);
+		SDL_Delay(1000 / cfg.targetFPS);
 #ifdef __WIN32
 		if(!updateTrayIcon()) quit = 1;
 #endif
   }
-	
+
 #ifdef __WIN32
 	removeTrayIcon();
 #endif

--- a/main.h
+++ b/main.h
@@ -51,6 +51,7 @@ typedef struct
   int      reloadRootWnd;
   int      monitorsCount;
   float    smooth;
+  int      targetFPS;
   Monitor *monitors;
 } Config;
 

--- a/parser.c
+++ b/parser.c
@@ -166,6 +166,12 @@ int parseConfig(App *app, Config *cfg)
   }
 	lwpLog(LOG_INFO, "	smooth: %f", cfg->smooth);
 
+  if (!findLine(f, "target_fps", TYPE_INT, &cfg->targetFPS))
+  {
+    lwpLog(LOG_INFO, "Can't find line 'target_fps' in config, setting to default value");
+    cfg->targetFPS = 60;
+  }
+
 #ifdef __LINUX
   if (!findLine(f, "reload_rootwindow", TYPE_INT, &cfg->reloadRootWnd))
   {

--- a/parser.c
+++ b/parser.c
@@ -171,7 +171,7 @@ int parseConfig(App *app, Config *cfg)
     lwpLog(LOG_INFO, "Can't find line 'target_fps' in config, setting to default value");
     cfg->targetFPS = 60;
   }
-	lwpLog(LOG_INFO, "	target_fps: %f", cfg->targetFPS);
+	lwpLog(LOG_INFO, "	target_fps: %d", cfg->targetFPS);
 
 #ifdef __LINUX
   if (!findLine(f, "reload_rootwindow", TYPE_INT, &cfg->reloadRootWnd))

--- a/parser.c
+++ b/parser.c
@@ -149,7 +149,7 @@ static int findLine(FILE *f, const char *name, int type, void *output)
 int parseConfig(App *app, Config *cfg)
 {
 	lwpLog(LOG_INFO, "Loading config file");
-	
+
   FILE *f = openConfigFile();
 
   if (!findLine(f, "monitors", TYPE_INT, &cfg->monitorsCount))
@@ -171,6 +171,7 @@ int parseConfig(App *app, Config *cfg)
     lwpLog(LOG_INFO, "Can't find line 'target_fps' in config, setting to default value");
     cfg->targetFPS = 60;
   }
+	lwpLog(LOG_INFO, "	target_fps: %f", cfg->targetFPS);
 
 #ifdef __LINUX
   if (!findLine(f, "reload_rootwindow", TYPE_INT, &cfg->reloadRootWnd))
@@ -213,7 +214,7 @@ int parseConfig(App *app, Config *cfg)
         lwpLog(LOG_ERROR, "Can't find line '%s' in config", str);
         return 0;
       }
-			if(p > 0) 
+			if(p > 0)
 				lwpLog(LOG_INFO, "		%s: %d", str, *(int*)(outputs[p]));
     }
 
@@ -264,7 +265,7 @@ int parseWallpaperConfig(Wallpaper *wallpaper, const char *path)
       lwpLog(LOG_ERROR, "Can't find line '%s' in config", paramStr[p]);
       return 0;
     }
-		
+
 		if (types[p] == TYPE_FLOAT)
 			lwpLog(LOG_INFO, "	%s: %f", paramStr[p], *(float*)(outputs[p]));
 		else
@@ -281,7 +282,7 @@ int parseWallpaperConfig(Wallpaper *wallpaper, const char *path)
     if (!findLine(f, str, TYPE_FLOAT, &wallpaper->layers[l].sensitivityX))
       wallpaper->layers[l].sensitivityX = defaultMovementX * l;
 		lwpLog(LOG_INFO, "		%s: %f", str, wallpaper->layers[l].sensitivityX);
-		
+
     snprintf(str, 100, "movement%d_y", l + 1);
     if (!findLine(f, str, TYPE_FLOAT, &wallpaper->layers[l].sensitivityY))
       wallpaper->layers[l].sensitivityY = defaultMovementY * l;
@@ -289,7 +290,7 @@ int parseWallpaperConfig(Wallpaper *wallpaper, const char *path)
   }
 
   fclose(f);
-	
+
 	lwpLog(LOG_INFO, "Wallpaper config file loaded");
   return 1;
 }


### PR DESCRIPTION
The times have come for high-refresh-rate monitors! 🖥\
This PR adds a new setting to the config: `target_fps`. It allows to indirectly set the `SDL_Delay` argument, by replacing the currently-hardcoded `1000 / 60` with `1000 / cfg.targetFPS`.

The setting is added to:
- `Config` struct
- `main.c` `SDL_Delay`
- All default configs with the value of `60`