### PR TITLE
Windows build conveniences

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ https://user-images.githubusercontent.com/38699473/220888934-09788a6b-873c-469b-
   cd lwp
   build.bat
   ```
-  - Download [SDL2](https://github.com/libsdl-org/SDL/releases/latest) and put `SDL2.dll` in `data` directory
+  - Download [SDL2](https://github.com/libsdl-org/SDL/releases/latest) and put `SDL2.dll` in repository root
   - Run `install.bat` as Administrator
   - Lwp should run immediately after the installation
   

--- a/build.bat
+++ b/build.bat
@@ -9,7 +9,7 @@ copy defaultWin.cfg data || goto err
 copy LICENSE data\LICENSE.txt || goto err
 echo.
 echo ---                           Done!                                  ---
-echo --- Remember to put SDL2.dll into 'data' directory before installing ---
+copy SDL2.dll data || echo --- Remember to put SDL2.dll into 'data' directory before installing ---
 pause>nul
 exit
 

--- a/build.bat
+++ b/build.bat
@@ -8,9 +8,14 @@ TYPE wallpapers\default-fullhd\wallpaper.cfg | FIND /V "" > data\wallpapers\defa
 copy uninstall.bat data || goto err
 copy defaultWin.cfg data || goto err
 copy LICENSE data\LICENSE.txt || goto err
+if exist SDL2.dll (
+  copy SDL2.dll data
+)
 echo.
 echo ---                           Done!                                  ---
-copy SDL2.dll data || echo --- Remember to put SDL2.dll into 'data' directory before installing ---
+if not exist SDL2.dll (
+  echo --- Remember to put SDL2.dll into 'data' directory before installing ---
+)
 pause>nul
 exit
 

--- a/build.bat
+++ b/build.bat
@@ -4,6 +4,7 @@ mkdir data || goto err
 windres resource.rc -O coff -o resource.res || goto err
 gcc -mwindows main.c wallpaper.c parser.c debug.c window.c resource.res -lmingw32 -lshcore -lSDL2main -lSDL2 -o data\lwp.exe || goto err
 xcopy wallpapers data\wallpapers\ /E /Y || goto err
+TYPE wallpapers\default-fullhd\wallpaper.cfg | FIND /V "" > data\wallpapers\default-fullhd\wallpaper.cfg
 copy uninstall.bat data || goto err
 copy defaultWin.cfg data || goto err
 copy LICENSE data\LICENSE.txt || goto err


### PR DESCRIPTION
This PR improves development experience on windows:
- Automatically converts `lf` to `crlf` in `wallpaper.cfg` (the program breaks with `lf` in this config on some windows environments)
- Adds auto-copy of `SDL2.dll` from project root to the `data` folder, as it is constantly being deleted, resulting in a need to copy the `SDL2.dll` over and over again.